### PR TITLE
feat: Support workflow auto approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module "entitlement_project" {
 |------|-------------|------|---------|:--------:|
 | enable\_approval\_workflow | Whether or not to allow access without approval | `bool` | `true` | no |
 | entitlement\_approval\_notification\_recipients | List of email addresses to be notified when a request is granted | `list(string)` | `[]` | no |
-| entitlement\_approvers | List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain | `list(string)` | `[]` | no |
+| entitlement\_approvers | List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain. Required if enable\_approval\_workflow is true (default) | `list(string)` | `[]` | no |
 | entitlement\_availability\_notification\_recipients | List of email addresses to be notified when a entitlement is created. These email addresses will receive an email about availability of the entitlement | `list(string)` | `[]` | no |
 | entitlement\_id | The ID to use for this Entitlement. This will become the last part of the resource name. This value should be 4-63 characters. This value should be unique among all other Entitlements under the specified parent | `string` | n/a | yes |
 | entitlement\_requesters | Required List of users, groups, service accounts or domains who can request grants using this entitlement. Can be one or more of Google Account email, Google Group, Service account or Google Workspace domain | `list(string)` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ module "entitlement_project" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| enable\_approval\_workflow | Whether or not to allow access without approval | `bool` | `true` | no |
+| auto\_approve\_entitlement | Whether or not to auto approve the entitlement. If true, entitlement will be auto approved without any manual approval | `bool` | `false` | no |
 | entitlement\_approval\_notification\_recipients | List of email addresses to be notified when a request is granted | `list(string)` | `[]` | no |
-| entitlement\_approvers | List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain. Required if enable\_approval\_workflow is true (default) | `list(string)` | `[]` | no |
+| entitlement\_approvers | List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain. Required if auto\_approve\_entitlement is false (default) | `list(string)` | `[]` | no |
 | entitlement\_availability\_notification\_recipients | List of email addresses to be notified when a entitlement is created. These email addresses will receive an email about availability of the entitlement | `list(string)` | `[]` | no |
 | entitlement\_id | The ID to use for this Entitlement. This will become the last part of the resource name. This value should be 4-63 characters. This value should be unique among all other Entitlements under the specified parent | `string` | n/a | yes |
 | entitlement\_requesters | Required List of users, groups, service accounts or domains who can request grants using this entitlement. Can be one or more of Google Account email, Google Group, Service account or Google Workspace domain | `list(string)` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ module "entitlement_project" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| enable\_approval\_workflow | Whether or not to allow access without approval | `bool` | `true` | no |
 | entitlement\_approval\_notification\_recipients | List of email addresses to be notified when a request is granted | `list(string)` | `[]` | no |
-| entitlement\_approvers | Required List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain | `list(string)` | n/a | yes |
+| entitlement\_approvers | List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain | `list(string)` | `[]` | no |
 | entitlement\_availability\_notification\_recipients | List of email addresses to be notified when a entitlement is created. These email addresses will receive an email about availability of the entitlement | `list(string)` | `[]` | no |
 | entitlement\_id | The ID to use for this Entitlement. This will become the last part of the resource name. This value should be 4-63 characters. This value should be unique among all other Entitlements under the specified parent | `string` | n/a | yes |
 | entitlement\_requesters | Required List of users, groups, service accounts or domains who can request grants using this entitlement. Can be one or more of Google Account email, Google Group, Service account or Google Workspace domain | `list(string)` | n/a | yes |

--- a/examples/cloud_pam_example/main.tf
+++ b/examples/cloud_pam_example/main.tf
@@ -56,6 +56,38 @@ module "entitlement_project" {
   ]
 }
 
+module "entitlement_project_no_approval" {
+  source  = "GoogleCloudPlatform/pam/google"
+  version = "~> 2.0"
+
+  entitlement_id = "example-entitlement-project-no-approval"
+  parent_id      = var.project_id
+  parent_type    = "project"
+
+  organization_id = var.org_id
+
+  grant_service_agent_permissions = true
+
+  enable_approval_workflow = false
+
+  entitlement_requesters = [
+    "user:dbadmin@develop.blueprints.joonix.net",
+  ]
+
+  role_bindings = [
+    {
+      role                 = "roles/storage.admin"
+      condition_expression = "request.time < timestamp(\"2024-04-23T18:30:00.000Z\")"
+    },
+    {
+      role = "roles/bigquery.admin"
+    }
+  ]
+  depends_on = [
+    google_project_service.pam_api_service
+  ]
+}
+
 module "entitlement_folder" {
   source  = "GoogleCloudPlatform/pam/google"
   version = "~> 2.0"

--- a/examples/cloud_pam_example/main.tf
+++ b/examples/cloud_pam_example/main.tf
@@ -68,7 +68,7 @@ module "entitlement_project_no_approval" {
 
   grant_service_agent_permissions = true
 
-  enable_approval_workflow = false
+  auto_approve_entitlement = true
 
   entitlement_requesters = [
     "user:dbadmin@develop.blueprints.joonix.net",

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "google_privileged_access_manager_entitlement" "entitlement" {
   }
 
   dynamic "approval_workflow" {
-    for_each = var.enable_approval_workflow ? ["approval_workflow_enabled"] : []
+    for_each = var.auto_approve_entitlement ? [] : ["approval_workflow_enabled"]
     content {
       manual_approvals {
         require_approver_justification = var.require_approver_justification

--- a/main.tf
+++ b/main.tf
@@ -82,15 +82,17 @@ resource "google_privileged_access_manager_entitlement" "entitlement" {
     }
   }
 
-  approval_workflow {  # Only 1 approval_workflow is allowed
-    manual_approvals { # Only 1 manual_approvals is allowed
-      require_approver_justification = var.require_approver_justification
-      # Only 1 step is allowed
-      steps {
-        approvals_needed          = 1
-        approver_email_recipients = var.entitlement_approval_notification_recipients
-        approvers {
-          principals = var.entitlement_approvers
+  dynamic "approval_workflow" {
+    for_each = var.enable_approval_workflow ? ["approval_workflow_enabled"] : []
+    content {
+      manual_approvals {
+        require_approver_justification = var.require_approver_justification
+        steps {
+          approvals_needed          = 1
+          approver_email_recipients = var.entitlement_approval_notification_recipients
+          approvers {
+            principals = var.entitlement_approvers
+          }
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "entitlement_requesters" {
 
 variable "entitlement_approvers" {
   type        = list(string)
-  description = "List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain"
+  description = "List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain. Required if enable_approval_workflow is true (default)"
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,8 @@ variable "entitlement_requesters" {
 
 variable "entitlement_approvers" {
   type        = list(string)
-  description = "Required List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain"
+  description = "List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain"
+  default     = []
 }
 
 variable "entitlement_approval_notification_recipients" {
@@ -96,4 +97,10 @@ variable "grant_service_agent_permissions" {
   type        = bool
   description = "Whether or not to grant roles/privilegedaccessmanager.serviceAgent role to PAM service account"
   default     = false
+}
+
+variable "enable_approval_workflow" {
+  type        = bool
+  description = "Whether or not to allow access without approval"
+  default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "entitlement_requesters" {
 
 variable "entitlement_approvers" {
   type        = list(string)
-  description = "List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain. Required if enable_approval_workflow is true (default)"
+  description = "List of users, groups or domain who can approve this entitlement. Can be one or more of Google Account email, Google Group or Google Workspace domain. Required if auto_approve_entitlement is false (default)"
   default     = []
 }
 
@@ -99,8 +99,8 @@ variable "grant_service_agent_permissions" {
   default     = false
 }
 
-variable "enable_approval_workflow" {
+variable "auto_approve_entitlement" {
   type        = bool
-  description = "Whether or not to allow access without approval"
-  default     = true
+  description = "Whether or not to auto approve the entitlement. If true, entitlement will be auto approved without any manual approval"
+  default     = false
 }


### PR DESCRIPTION
With `approval_workflow` block being optional in the Google Cloud terraform provider [resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/privileged_access_manager_entitlement#approval_workflow-1) (and the same functionality being available in the web console via the "Activate access without approvals" option), changes in this PR make the entire block dependant on `enable_approval_workflow` (bool) variable. 

I contemplated making the approval workflow dependant on length of `entitlement_approvers` list, in the end I've decided to go with a new variable since it seems to me like more options could be added to approval workflows structure and binding this "switch" to one of the possible inputs didn't seem right. I am open to suggestions if that doesn't feel right.